### PR TITLE
Fixes license value in package.json

### DIFF
--- a/bibisco/app/package.json
+++ b/bibisco/app/package.json
@@ -3,7 +3,7 @@
   "productName": "bibisco",
   "version": "2.3.1",
   "description": "writing novel application",
-  "license": "GPL v3",
+  "license": "GPL-3.0-or-later",
   "repository": "https://github.com/andreafeccomandi/bibisco",
   "author": {
     "name": "Andrea Feccomandi",


### PR DESCRIPTION
Makes sure to use SPDX conformant license string

**Note:** I do not wish to perform an overly complex CAA signing procedure for something as simplistic as this. Perhaps automate this so its easier for people to contribute.